### PR TITLE
Fix published package

### DIFF
--- a/.changeset/itchy-berries-hug.md
+++ b/.changeset/itchy-berries-hug.md
@@ -1,0 +1,5 @@
+---
+"tiptap-steps": patch
+---
+
+Fix broken package

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -28,7 +28,10 @@ jobs:
       
       - name: Install dependencies
         run: pnpm install
-      
+
+      - name: Build package
+        run: pnpm build
+
       - name: Create and publish versions
         uses: changesets/action@v1
         with:

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"scripts": {
 		"preinstall": "npx only-allow pnpm",
 		"ci:publish": "pnpm publish -r",
+		"build": "pnpm --filter tiptap-steps build",
 		"test": "pnpm --filter tiptap-steps test",
 		"test:coverage": "pnpm --filter tiptap-steps test:coverage"
 	},

--- a/package/package.json
+++ b/package/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.1",
 	"description": "A step-by-step guide extension for Tiptap",
 	"main": "dist/index.js",
-	"module": "dist/index.mjs",
+	"module": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"type": "module",
 	"scripts": {
@@ -14,19 +14,12 @@
 		"test:coverage": "vitest --coverage"
 	},
 	"exports": {
-		"import": "./dist/index.mjs",
-		"require": "./dist/index.js"
+		"import": "./dist/index.js",
+		"require": "./dist/index.cjs"
 	},
-	"keywords": [
-		"tiptap",
-		"tiptap extension",
-		"tiptap steps",
-		"prosemirror"
-	],
+	"keywords": ["tiptap", "tiptap extension", "tiptap steps", "prosemirror"],
 	"author": "Eva Decker",
-	"files": [
-		"dist/"
-	],
+	"files": ["dist/"],
 	"license": "MIT",
 	"devDependencies": {
 		"@tiptap/core": "^2.11.7",
@@ -47,7 +40,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/namesakefyi/tiptap-steps.git",
+		"url": "git+https://github.com/namesakefyi/tiptap-steps.git",
 		"directory": "package"
 	},
 	"packageManager": "pnpm@9.11.0"


### PR DESCRIPTION
The `package.json` settings were configured incorrectly with `tsup` leading to a broken package install. This fixes them with the help of https://publint.dev/