### PR TITLE
Fix Stackblitz example

### DIFF
--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -19,7 +19,7 @@
 		"@tiptap/starter-kit": "^2.11.7",
 		"react": "^19.0.0",
 		"react-dom": "^19.0.0",
-		"tiptap-steps": "../../"
+		"tiptap-steps": "^2.0.0"
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.22.0",
@@ -30,6 +30,7 @@
 		"eslint-plugin-react-hooks": "^5.2.0",
 		"eslint-plugin-react-refresh": "^0.4.19",
 		"globals": "^16.0.0",
+		"tiptap-steps": "file:../../",
 		"typescript": "~5.7.2",
 		"typescript-eslint": "^8.26.1",
 		"vite": "^6.3.1"

--- a/examples/react/pnpm-lock.yaml
+++ b/examples/react/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^19.0.0
         version: 19.1.0(react@19.1.0)
       tiptap-steps:
-        specifier: ../../
-        version: link:../..
+        specifier: ^2.0.0
+        version: 2.0.0(@tiptap/core@2.11.7(@tiptap/pm@2.11.7))
     devDependencies:
       '@eslint/js':
         specifier: ^9.22.0
@@ -1258,6 +1258,11 @@ packages:
 
   tippy.js@6.3.7:
     resolution: {integrity: sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==}
+
+  tiptap-steps@2.0.0:
+    resolution: {integrity: sha512-2g3L24oGe/vBAvmOvz7lqs64f+DgZxgzV6e0dDazVVo4IgGCgS63/d3fdNspiIyy67HYxU2yPV4gPsMSJ4S6Rw==}
+    peerDependencies:
+      '@tiptap/core': ^2.11.7
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -2565,6 +2570,10 @@ snapshots:
   tippy.js@6.3.7:
     dependencies:
       '@popperjs/core': 2.11.8
+
+  tiptap-steps@2.0.0(@tiptap/core@2.11.7(@tiptap/pm@2.11.7)):
+    dependencies:
+      '@tiptap/core': 2.11.7(@tiptap/pm@2.11.7)
 
   to-regex-range@5.0.1:
     dependencies:

--- a/package.json
+++ b/package.json
@@ -25,16 +25,9 @@
     "import": "./dist/index.js",
     "require": "./dist/index.cjs"
   },
-  "keywords": [
-    "tiptap",
-    "tiptap extension",
-    "tiptap steps",
-    "prosemirror"
-  ],
+  "keywords": ["tiptap", "tiptap extension", "tiptap steps", "prosemirror"],
   "author": "Eva Decker",
-  "files": [
-    "dist/"
-  ],
+  "files": ["dist/"],
   "license": "MIT",
   "devDependencies": {
     "@biomejs/biome": "1.9.4",


### PR DESCRIPTION
Point to published dependency for `tiptap-steps` but override with devDependency when developing.